### PR TITLE
Do not assume that posts have summaries

### DIFF
--- a/layouts/partials/extras.gemini.gmi
+++ b/layouts/partials/extras.gemini.gmi
@@ -48,7 +48,9 @@
 {{- if .OutputFormats.Get "gemini" }}
 {{- $postLink := replace .RelPermalink "/gemini" "" 1 -}}
 => {{ replace $postLink "/gemini-page" "" 1}}  {{.Date.Format "January 2, 2006"}} {{ .Title }}
+{{ if .Params.summary }}
 {{ .Params.summary }}
+{{ end }}
 {{ end }}
 {{- end }}
 {{ end }}

--- a/layouts/partials/extras.gopher.txt
+++ b/layouts/partials/extras.gopher.txt
@@ -43,7 +43,9 @@ i{{ $.Site.Params.gopher.postText }}
 {{- range where .Site.RegularPages "Type" "posts" -}}
 {{- if .OutputFormats.Get "gopher" }}
 1{{ .Title }}	{{ replace .RelPermalink "/gopher" "" 1 }}
+{{- if .Params.summary }}
 i{{ .Params.summary }}
+{{ end }}
 i
 {{ end }}
 {{ end }}


### PR DESCRIPTION
On my blog I never wrote post summaries. And this generates a list that looks like this:

```
18 (DIR) Blog Post Title
         <no value>
```

So I added a check for if a post has a summary.