### PR TITLE
fix cut off documents caused by skipLine and code sections

### DIFF
--- a/src/hugo2gg.py
+++ b/src/hugo2gg.py
@@ -725,7 +725,7 @@ def convert_gopher(src, dst, arPath, arLast, arBase):
                 flDst.write(line)
                 continue
             line = line.rstrip('\r\n') # remove trailing <CR> and/or <LF>
-            if line == 'i---' or line == 'i+++':
+            if not isFenced and (line == 'i---' or line == 'i+++'):
                 skipLine = not skipLine 
                 continue
             if skipLine:
@@ -743,8 +743,6 @@ def convert_gopher(src, dst, arPath, arLast, arBase):
                     error("Non 'i' Fenced line") 
 
                 flDst.write(line + ('\t/' if len(linePart) < 2 else '') + lineEnd)
-                continue
-            if not line:
                 continue
             if line.strip() == '[[[=> references <=]]]':
                 print_references('i' if addItemForText else '')
@@ -913,7 +911,7 @@ def convert_gemini(src, dst, arPath, arLast, arBase):
             if arg and arg['keepRaw']:
                 flDst.write(line)
                 continue
-            if line.strip('\r\n') in ['---', '+++']:
+            if not isFenced and line.strip('\r\n') in ['---', '+++']:
                 skipLine = not skipLine 
                 continue
             if skipLine:

--- a/src/hugo2gg.py
+++ b/src/hugo2gg.py
@@ -919,6 +919,7 @@ def convert_gemini(src, dst, arPath, arLast, arBase):
             if re.search(r"^\s*```",line): #toggle fenced code
                 flDst.write(line.strip('\t\r\n ') + '\n')
                 isFenced  = not isFenced
+                emptyLines = 0
                 continue
             if isFenced or ((len(line) > 3) and ((line[0:4] == '    ') or (line[0:1] == '\t'))):
                 flDst.write(line.rstrip('\r\n ') + '\n')


### PR DESCRIPTION
I posted a diff into one of my posts within a fenced code section. As soon as convert_gopher and convert_gemini encounterned a line with just ---, the document would be cut off in the line after.

Such lines can be encountered for example in a Unix mailbox formatted email. In this case my blog post contains a paste of one in a fenced code section.

```
From: X
Subject: Hello Patch
	
---	
 fun-file          | 3 ++-	
[ and so on...]
```
